### PR TITLE
Updated plist DVTPlugInCompatibilityUUIDs with Xcode 6.1 UUID

### DIFF
--- a/RevealPlugin/RevealPlugin-Info.plist
+++ b/RevealPlugin/RevealPlugin-Info.plist
@@ -45,6 +45,7 @@
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
 		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
+		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2014 Saick. All rights reserved.</string>


### PR DESCRIPTION
Added Xcode 6.1 UUID to the Info.plist to allow for functionality within Xcode 6.1.