### PR TITLE
Log didLoaded only when current application is Xcode

### DIFF
--- a/RevealPlugin/RevealPlugin.m
+++ b/RevealPlugin/RevealPlugin.m
@@ -33,9 +33,9 @@
 
 + (void)pluginDidLoad:(NSBundle *)plugin
 {
-  NSLog(@"Reveal plugin DidLoaded");
   NSString *currentApplicationName = [[NSBundle mainBundle] infoDictionary][@"CFBundleName"];
   if ([currentApplicationName isEqual:@"Xcode"]) {
+    NSLog(@"Reveal plugin DidLoaded");
     [self shared];
   }
 }


### PR DESCRIPTION
Otherwise it prints during terminal xcodebuild runs as well, where Reveal is totally irrelevant.